### PR TITLE
Fix code scanning alert no. 4: Flask app is run in debug mode

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -141,4 +141,5 @@ def fetch_messages(room_id):
 
      
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/ooz-zoo/secure_chat_web/security/code-scanning/4](https://github.com/ooz-zoo/secure_chat_web/security/code-scanning/4)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to use an environment variable to control the debug mode. This way, we can easily switch between development and production configurations without changing the code.

1. Modify the `app.run()` call to use an environment variable to determine whether to enable debug mode.
2. Import the `os` module if it is not already imported.
3. Set the default value of the environment variable to `False` to ensure that debug mode is disabled by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
